### PR TITLE
Fixed scope of "True", "False" and "None" keywords

### DIFF
--- a/syntaxes/kv.tmLanguage.json
+++ b/syntaxes/kv.tmLanguage.json
@@ -27,7 +27,11 @@
 		},
 		{
 			"name": "entity.name.tag.kv",
-			"match": "\\b(True|None|False|self|app|root|nonlocal|is|lambda|and|not|or|in)\\b"
+			"match": "\\b(self|app|root|nonlocal|is|lambda|and|not|or|in)\\b"
+		},
+		{
+			"name": "constant.language.kv",
+			"match": "\\b(True|False|None)\\b"
 		},
 		{
 			"explanation": "A KvLang syntax of special key word attributes",


### PR DESCRIPTION
Changed the scope of the `True`, `False`, and `None` keywords from `entity.name.tag.kv` to `constant.language.kv` to be consistent with the scope of those keywords in the grammars in [Microsoft/vscode-python](https://github.com/Microsoft/vscode-python).

Although unnoticeable when using the default Dark+ theme, certain themes (such as the [One Monokai Theme](https://marketplace.visualstudio.com/items?itemName=azemoh.one-monokai)) differentiate the colors they use for the `entity.name.tag` and `constant.language` scopes. This will make those keywords appear the expected color in `kv` files.