### PR TITLE
Added ability to use `python.pythonPath` as `kvlang.pythonPath`

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -100,7 +100,16 @@ function updatePythonPath(): void {
 
 function getPythonPath(): string {
 	const configuration = workspace.getConfiguration('kvlang', null);
-	let pythonPath = configuration.get('pythonPath', undefined);
+	let pythonPath: any;
+	let useDefaultPythonPath = configuration.get('useDefaultPythonPath', false);
+
+	// If 'useDefaultPythonPath' is set, try to get the config from python.pythonPath first
+	if (useDefaultPythonPath) {
+		let defaultPythonPath = workspace.getConfiguration('python', null).get('pythonPath', undefined);
+		pythonPath = defaultPythonPath || (configuration.get('pythonPath', undefined));
+	} else {
+		pythonPath = configuration.get('pythonPath', undefined);
+	}
 
 	if (pythonPath === undefined) {
 		console.error('KvLang: PythonPath is undefined. Assigned default value of python path')

--- a/package.json
+++ b/package.json
@@ -39,6 +39,12 @@
                     "type": "string",
                     "default": "python",
                     "description": "Python path which will be used by KvLang Language Server."
+                },
+                "kvlang.useDefaultPythonPath": {
+                    "scope": "resource",
+                    "type": "boolean",
+                    "default": false,
+                    "markdownDescription": "If enabled, the KvLang Language Server will use the python path specified by `python.pythonPath` (The Python path specified in the Python extension)"
                 }
             }
         },


### PR DESCRIPTION
For users (like myself) that use Python virtual environments in their projects, it can be a pain to essentially set the interpreter path twice. This PR adds a configuration option, `kvlang.useDefaultPythonPath`, which when enabled, will detect and prioritize the path specified in `python.pythonPath` over `kvlang.pythonPath`.

I tried to implement this without changing the fundamental workings of this extension, however I have a few thoughts/suggestions that might improve the usability of this feature:
- Configuration defaults to `true` (I didn't feel it was my place to make that choice)
- The default `kvlang.pythonPath` configuration should instead be a blank string. If there is a path specified, it will use that first. Otherwise, it will check if `python.pythonPath` is specified and use that, and if it still isn't specified, it will default to `python`. **I personally think something like this would work best**

I implemented a similar system in one of my vscode extensions so I wouldn't mind adding that behavior here if you want. Alternatively, if you have other preferences for how a system like this would work, I'm open to suggestions!